### PR TITLE
Add reply_get_rooms_done reply

### DIFF
--- a/internal/lobbyServer/lobby.go
+++ b/internal/lobbyServer/lobby.go
@@ -41,6 +41,7 @@ const (
 	TypeReplyPlayers       = "reply_players"
 	TypeRequestGetRooms    = "request_get_rooms"
 	TypeReplyGetRooms      = "reply_get_rooms"
+	TypeReplyGetRoomsDone  = "reply_get_rooms_done"
 	TypeRequestCreateRoom  = "request_create_room"
 	TypeReplyCreateRoom    = "reply_create_room"
 	TypeRequestJoinRoom    = "request_join_room"
@@ -389,6 +390,11 @@ func (s *LobbyServer) wsHandler(ws *websocket.Conn) {
 					if err := s.sendData(ws, sendMessage); err != nil {
 						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
 					}
+				}
+				sendMessage.Accept = Accepted
+				sendMessage.Type = TypeReplyGetRoomsDone
+				if err := s.sendData(ws, sendMessage); err != nil {
+					s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
 				}
 			}
 		} else if receivedMessage.Type == TypeRequestJoinRoom {


### PR DESCRIPTION
This adds a `reply_get_rooms_done` reply when the server has sent all the rooms to the client.

This allows a client to signal to users that retrieving the rooms has been finished, and can for example allow a client to show something like the following:
![image](https://github.com/user-attachments/assets/8cc641c5-b76e-4330-86ff-52de1f6969a7)
