### PR TITLE
Fix linter and better check for correct player

### DIFF
--- a/internal/lobbyServer/lobby.go
+++ b/internal/lobbyServer/lobby.go
@@ -117,6 +117,15 @@ func (s *LobbyServer) findGameServer(port int) (string, *gameserver.GameServer) 
 	return "", nil
 }
 
+func (s *LobbyServer) findRoomCreator(g *gameserver.GameServer) *gameserver.Client {
+	for _, v := range g.Players {
+		if v.Number == 0 {
+			return &v
+		}
+	}
+	return nil
+}
+
 func (s *LobbyServer) updatePlayers(g *gameserver.GameServer) {
 	if g == nil {
 		return
@@ -401,12 +410,8 @@ func (s *LobbyServer) wsHandler(ws *websocket.Conn) {
 			roomName, g := s.findGameServer(receivedMessage.Room.Port)
 
 			if g != nil {
-				var roomCreator *gameserver.Client
-				for _, v := range g.Players {
-					if v.Number == 0 {
-						roomCreator = &v
-					}
-				}
+				roomCreator := s.findRoomCreator(g)
+
 				if roomCreator.Socket != ws {
 					sendMessage.Accept = BadPlayer
 					sendMessage.Message = "Player must be room creator"
@@ -610,12 +615,8 @@ func (s *LobbyServer) wsHandler(ws *websocket.Conn) {
 			sendMessage.Type = TypeReplyBeginGame
 			roomName, g := s.findGameServer(receivedMessage.Room.Port)
 			if g != nil {
-				var roomCreator *gameserver.Client
-				for _, v := range g.Players {
-					if v.Number == 0 {
-						roomCreator = &v
-					}
-				}
+				roomCreator := s.findRoomCreator(g)
+
 				if roomCreator.Socket != ws {
 					sendMessage.Accept = BadPlayer
 					sendMessage.Message = "Player must be room creator"

--- a/internal/lobbyServer/lobby.go
+++ b/internal/lobbyServer/lobby.go
@@ -33,9 +33,10 @@ const (
 	BadName         = 6
 	BadEmulator     = 7
 	BadAuth         = 8
-	BadIP           = 9
+	BadPlayer       = 9
 	BadRoomName     = 10
-	Other           = 11
+	BadGameState    = 11
+	Other           = 12
 )
 
 const (
@@ -400,33 +401,21 @@ func (s *LobbyServer) wsHandler(ws *websocket.Conn) {
 			roomName, g := s.findGameServer(receivedMessage.Room.Port)
 
 			if g != nil {
-				ip, _, err := net.SplitHostPort(ws.Request().RemoteAddr)
-				if err != nil {
-					g.Logger.Error(err, "could not parse IP", "IP", ws.Request().RemoteAddr)
-				}
-
-				var player = g.Players[receivedMessage.PlayerName]
-				if player.Number != 0 {
-					sendMessage.Accept = BadName
-					sendMessage.Message = "Player name must match room creator name"
-					if err := s.sendData(ws, sendMessage); err != nil {
-						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
+				var roomCreator *gameserver.Client
+				for _, v := range g.Players {
+					if v.Number == 0 {
+						roomCreator = &v
 					}
-				} else if ip != player.IP {
-					sendMessage.Accept = BadIP
-					sendMessage.Message = "Player IP must match IP of room creator"
+				}
+				if roomCreator.Socket != ws {
+					sendMessage.Accept = BadPlayer
+					sendMessage.Message = "Player must be room creator"
 					if err := s.sendData(ws, sendMessage); err != nil {
 						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
 					}
 				} else if g.Running {
-					sendMessage.Accept = Other
+					sendMessage.Accept = BadGameState
 					sendMessage.Message = "Game is already running"
-					if err := s.sendData(ws, sendMessage); err != nil {
-						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
-					}
-				} else if receivedMessage.Emulator != g.Emulator {
-					sendMessage.Accept = BadEmulator
-					sendMessage.Message = "Emulator name must match room emulator"
 					if err := s.sendData(ws, sendMessage); err != nil {
 						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
 					}
@@ -621,13 +610,32 @@ func (s *LobbyServer) wsHandler(ws *websocket.Conn) {
 			sendMessage.Type = TypeReplyBeginGame
 			roomName, g := s.findGameServer(receivedMessage.Room.Port)
 			if g != nil {
-				if g.Running {
-					g.Logger.Error(fmt.Errorf("game already running"), "game running", "message", receivedMessage, "address", ws.Request().RemoteAddr)
+				var roomCreator *gameserver.Client
+				for _, v := range g.Players {
+					if v.Number == 0 {
+						roomCreator = &v
+					}
+				}
+				if roomCreator.Socket != ws {
+					sendMessage.Accept = BadPlayer
+					sendMessage.Message = "Player must be room creator"
+					if err := s.sendData(ws, sendMessage); err != nil {
+						// only sent back to the player who tried to start the game
+						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
+					}
+				} else if g.Running {
+					sendMessage.Accept = BadGameState
+					sendMessage.Message = "Game is already running"
+					if err := s.sendData(ws, sendMessage); err != nil {
+						// only sent back to the player who tried to start the game
+						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
+					}
 				} else {
 					g.Running = true
 					g.StartTime = time.Now()
 					g.Logger.Info("starting game", "time", g.StartTime.Format(time.RFC3339))
 					g.NumberOfPlayers = len(g.Players)
+					sendMessage.Accept = Accepted
 					go s.watchGameServer(roomName, g)
 					for _, v := range g.Players {
 						if err := s.sendData(v.Socket, sendMessage); err != nil {

--- a/internal/lobbyServer/lobby.go
+++ b/internal/lobbyServer/lobby.go
@@ -621,14 +621,12 @@ func (s *LobbyServer) wsHandler(ws *websocket.Conn) {
 					sendMessage.Accept = BadPlayer
 					sendMessage.Message = "Player must be room creator"
 					if err := s.sendData(ws, sendMessage); err != nil {
-						// only sent back to the player who tried to start the game
 						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
 					}
 				} else if g.Running {
 					sendMessage.Accept = BadGameState
 					sendMessage.Message = "Game is already running"
 					if err := s.sendData(ws, sendMessage); err != nil {
-						// only sent back to the player who tried to start the game
 						s.Logger.Error(err, "failed to send message", "message", sendMessage, "address", ws.Request().RemoteAddr)
 					}
 				} else {


### PR DESCRIPTION
Rather than checking receivedMessage.PlayerName and player.IP, it is possible to check if the webSocket connection is the same one as player number 0.

Also I remove the check for `if receivedMessage.Emulator != g.Emulator`, since this should have already been checked when the player created or joined the room

I also took the opportunity to add the check for player 0 to begin_game, since only player 0 should be starting the game